### PR TITLE
fix: Remove unused global current_session in network_tracker

### DIFF
--- a/albion_insight/core/network_tracker.py
+++ b/albion_insight/core/network_tracker.py
@@ -25,7 +25,6 @@ def process_packet(packet):
             f"para {packet[IP].dst}:{packet[IP].dport}"
         )
         # Simulação de atualização de estatísticas (a ser substituída pela lógica real)
-        global current_session
         current_session.total_silver += 1
         current_session.total_fame += 1
 


### PR DESCRIPTION
Remove a declaração  desnecessária em  que estava causando o erro F824 (unused global).