### PR TITLE
fix(network): Corrige problema de quebra de linha dupla na comunicação sniffer-UI

### DIFF
--- a/albion_insight/core/network_tracker.py
+++ b/albion_insight/core/network_tracker.py
@@ -34,7 +34,7 @@ def process_packet(packet):
         if protocol_decoder.decode_and_update(bytes(packet)):
             # Se decodificado com sucesso, envia um sinal para a UI
             # No futuro, o ProtocolDecoder enviará os dados diretamente para a UI
-            print(f"DATA:SILVER:{current_session.total_silver}")
+            print(f"DATA:SILVER:{current_session.total_silver}", end="")
             sys.stdout.flush()
         logger.debug(
             "Pacote Albion Online recebido de %s:%s para %s:%s",

--- a/albion_insight/core/sniffer_manager.py
+++ b/albion_insight/core/sniffer_manager.py
@@ -25,7 +25,7 @@ class SnifferManager:
                 line = self.sniffer_process.stdout.readline()
                 if not line:
                     break
-                line = line.decode("utf-8").strip()
+                line = line.decode("utf-8")
                 if line:
                     logger.debug(f"Sniffer Output: {line}")
                     self.data_queue.append(line)


### PR DESCRIPTION
Ajusta a forma como os dados são enviados via  no  e lidos no  para evitar a adição de quebras de linha duplicadas, o que estava causando problemas de parsing na UI. Isso resolve o problema de 'bug/quebra' mencionado na descrição do projeto.